### PR TITLE
Removed .g file type

### DIFF
--- a/lark.tmLanguage
+++ b/lark.tmLanguage
@@ -4,7 +4,6 @@
 <dict>
 	<key>fileTypes</key>
 	<array>
-		<string>g</string>
 		<string>lark</string>
 		<string>lr</string>
 	</array>


### PR DESCRIPTION
Since .g is the old file type that's associated with ANTLR, I removed it from Lark highlighting. Especially since people should still be able to select it themselves if they need to.